### PR TITLE
Fix crash when the adapter changes its content

### DIFF
--- a/rtlviewpager/src/main/java/com/booking/rtlviewpager/PagerAdapterWrapper.java
+++ b/rtlviewpager/src/main/java/com/booking/rtlviewpager/PagerAdapterWrapper.java
@@ -15,6 +15,7 @@
  */
 package com.booking.rtlviewpager;
 
+import android.database.DataSetObservable;
 import android.database.DataSetObserver;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -29,9 +30,23 @@ class PagerAdapterWrapper extends PagerAdapter {
 
     @NonNull
     private final PagerAdapter adapter;
+    private final DataSetObservable dataSetObservable = new DataSetObservable();
+
 
     protected PagerAdapterWrapper(@NonNull PagerAdapter adapter) {
         this.adapter = adapter;
+        this.adapter.registerDataSetObserver(new DataSetObserver() {
+            @Override
+            public void onChanged() {
+                PagerAdapterWrapper.super.notifyDataSetChanged();
+                dataSetObservable.notifyChanged();
+            }
+
+            @Override
+            public void onInvalidated() {
+                dataSetObservable.notifyInvalidated();
+            }
+        });
     }
 
     @NonNull
@@ -86,12 +101,12 @@ class PagerAdapterWrapper extends PagerAdapter {
 
     @Override
     public void registerDataSetObserver(DataSetObserver observer) {
-        adapter.registerDataSetObserver(observer);
+        dataSetObservable.registerObserver(observer);
     }
 
     @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
-        adapter.unregisterDataSetObserver(observer);
+        dataSetObservable.unregisterObserver(observer);
     }
 
     @Override


### PR DESCRIPTION
`PagerAdapterWrapper`should call `super.notifyDataSetChanged()`when a change happens  in the wrapped `PageAdapter` otherwise you get the following error:

> The application's PagerAdapter changed the adapter's contents without calling PagerAdapter#notifyDataSetChanged
